### PR TITLE
Fixing messages concatenated

### DIFF
--- a/app/src/main/java/com/p2p/data/loadingMessages/LoadingSource.kt
+++ b/app/src/main/java/com/p2p/data/loadingMessages/LoadingSource.kt
@@ -1,9 +1,13 @@
 package com.p2p.data.loadingMessages
-import com.p2p.model.base.message.Message
 
-/** This interface brings the capacity to show loading messages from message. */
+/** This interface brings the capacity to show loading messages from message types. */
 interface LoadingSource {
 
-    /** Returns the loading text while the [message] is being send . */
-    fun getLoadingText(messageType: String): String
+    /** Returns the loading text for the give [messageType]. */
+    fun getLoadingText(messageType: MessageType): String
+
+    enum class MessageType {
+        TF_WAITING_FOR_REVIEW,
+        TF_WAITING_FOR_WORDS
+    }
 }

--- a/app/src/main/java/com/p2p/data/loadingMessages/LoadingSource.kt
+++ b/app/src/main/java/com/p2p/data/loadingMessages/LoadingSource.kt
@@ -1,13 +1,11 @@
 package com.p2p.data.loadingMessages
 
+import com.p2p.model.LoadingMessageType
+
 /** This interface brings the capacity to show loading messages from message types. */
 interface LoadingSource {
 
     /** Returns the loading text for the give [messageType]. */
-    fun getLoadingText(messageType: MessageType): String
+    fun getLoadingText(messageType: LoadingMessageType): String
 
-    enum class MessageType {
-        TF_WAITING_FOR_REVIEW,
-        TF_WAITING_FOR_WORDS
-    }
 }

--- a/app/src/main/java/com/p2p/data/loadingMessages/LoadingTextRepository.kt
+++ b/app/src/main/java/com/p2p/data/loadingMessages/LoadingTextRepository.kt
@@ -1,6 +1,8 @@
 package com.p2p.data.loadingMessages
 
+import com.p2p.model.LoadingMessageType
+
 data class LoadingTextRepository(private val loadingSource: LoadingSource) {
 
-    fun getText(messageType: LoadingSource.MessageType) = loadingSource.getLoadingText(messageType)
+    fun getText(messageType: LoadingMessageType) = loadingSource.getLoadingText(messageType)
 }

--- a/app/src/main/java/com/p2p/data/loadingMessages/LoadingTextRepository.kt
+++ b/app/src/main/java/com/p2p/data/loadingMessages/LoadingTextRepository.kt
@@ -2,5 +2,5 @@ package com.p2p.data.loadingMessages
 
 data class LoadingTextRepository(private val loadingSource: LoadingSource) {
 
-    fun getText(messageType: String): String = loadingSource.getLoadingText(messageType)
+    fun getText(messageType: LoadingSource.MessageType) = loadingSource.getLoadingText(messageType)
 }

--- a/app/src/main/java/com/p2p/framework/LoadingTextLocalResourcesSource.kt
+++ b/app/src/main/java/com/p2p/framework/LoadingTextLocalResourcesSource.kt
@@ -1,21 +1,20 @@
 package com.p2p.framework
 
 import android.content.Context
+import androidx.annotation.StringRes
 import com.p2p.R
-import com.p2p.data.instructions.InstructionsSource
 import com.p2p.data.loadingMessages.LoadingSource
-import com.p2p.model.base.message.Message
-import com.p2p.model.tuttifrutti.message.TuttiFruttiEnoughForMeEnoughForAllMessage
-import com.p2p.presentation.home.games.Game
-import com.p2p.utils.getString
 
 /**Instructions for all games*/
-class LoadingTextLocalResourcesSource(private val context: Context) : LoadingSource {
-    val textByMessage = mapOf(
-        TuttiFruttiEnoughForMeEnoughForAllMessage.TYPE to context.resources.getString(R.string.tf_wait_for_results)
+class LoadingTextLocalResourcesSource(context: Context) : LoadingSource {
+
+    private val textByMessage = mapOf(
+        LoadingSource.MessageType.TF_WAITING_FOR_REVIEW to getString(context, R.string.tf_wait_for_review),
+        LoadingSource.MessageType.TF_WAITING_FOR_WORDS to getString(context, R.string.tf_wait_for_words)
     )
 
-    override fun getLoadingText(messageType: String): String =
-        textByMessage[messageType] ?: ""
+    private fun getString(context: Context, @StringRes stringRes: Int) = context.resources.getString(stringRes)
+
+    override fun getLoadingText(messageType: LoadingSource.MessageType) = textByMessage[messageType].orEmpty()
 
 }

--- a/app/src/main/java/com/p2p/framework/LoadingTextLocalResourcesSource.kt
+++ b/app/src/main/java/com/p2p/framework/LoadingTextLocalResourcesSource.kt
@@ -4,17 +4,18 @@ import android.content.Context
 import androidx.annotation.StringRes
 import com.p2p.R
 import com.p2p.data.loadingMessages.LoadingSource
+import com.p2p.model.LoadingMessageType
 
 /**Instructions for all games*/
 class LoadingTextLocalResourcesSource(context: Context) : LoadingSource {
 
     private val textByMessage = mapOf(
-        LoadingSource.MessageType.TF_WAITING_FOR_REVIEW to getString(context, R.string.tf_wait_for_review),
-        LoadingSource.MessageType.TF_WAITING_FOR_WORDS to getString(context, R.string.tf_wait_for_words)
+        LoadingMessageType.TF_WAITING_FOR_REVIEW to getString(context, R.string.tf_wait_for_review),
+        LoadingMessageType.TF_WAITING_FOR_WORDS to getString(context, R.string.tf_wait_for_words)
     )
 
     private fun getString(context: Context, @StringRes stringRes: Int) = context.resources.getString(stringRes)
 
-    override fun getLoadingText(messageType: LoadingSource.MessageType) = textByMessage[messageType].orEmpty()
+    override fun getLoadingText(messageType: LoadingMessageType) = textByMessage[messageType].orEmpty()
 
 }

--- a/app/src/main/java/com/p2p/framework/LoadingTextLocalResourcesSource.kt
+++ b/app/src/main/java/com/p2p/framework/LoadingTextLocalResourcesSource.kt
@@ -14,8 +14,7 @@ class LoadingTextLocalResourcesSource(context: Context) : LoadingSource {
         LoadingMessageType.TF_WAITING_FOR_WORDS to getString(context, R.string.tf_wait_for_words)
     )
 
-    private fun getString(context: Context, @StringRes stringRes: Int) = context.resources.getString(stringRes)
-
     override fun getLoadingText(messageType: LoadingMessageType) = textByMessage[messageType].orEmpty()
 
+    private fun getString(context: Context, @StringRes stringRes: Int) = context.resources.getString(stringRes)
 }

--- a/app/src/main/java/com/p2p/framework/bluetooth/BluetoothClient.kt
+++ b/app/src/main/java/com/p2p/framework/bluetooth/BluetoothClient.kt
@@ -17,6 +17,7 @@ class BluetoothClient(
 
     /** This [BluetoothConnectionThread] contains the communication with the server. */
     private var connectionToServer: BluetoothConnectionThread? = null
+    private val messageSenderThread = MessageSenderThread()
 
     private var isClosed = false
 
@@ -90,7 +91,7 @@ class BluetoothClient(
     }
 
     private fun write(message: Message, isConversation: Boolean) {
-        connectionToServer?.let { writeOnConnection(it, message, isConversation) }
+        connectionToServer?.let { sendMessage(messageSenderThread, it, message, isConversation) }
     }
 
     companion object {

--- a/app/src/main/java/com/p2p/framework/bluetooth/BluetoothConnectionImp.kt
+++ b/app/src/main/java/com/p2p/framework/bluetooth/BluetoothConnectionImp.kt
@@ -3,13 +3,13 @@ package com.p2p.framework.bluetooth
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothSocket
 import android.os.Handler
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.p2p.data.bluetooth.BluetoothConnection
 import com.p2p.model.base.message.Message
 
 abstract class BluetoothConnectionImp(protected val handler: Handler) : Thread(), BluetoothConnection {
 
-    private val objectMapper by lazy { ObjectMapper() }
+    private val objectMapper by lazy { jacksonObjectMapper() }
 
     protected val bluetoothAdapter: BluetoothAdapter? = BluetoothAdapter.getDefaultAdapter()
 
@@ -17,8 +17,13 @@ abstract class BluetoothConnectionImp(protected val handler: Handler) : Thread()
         return BluetoothConnectionThread(handler, bluetoothSocket)
     }
 
-    protected fun writeOnConnection(connection: BluetoothConnectionThread, message: Message, isConversation: Boolean) {
+    protected fun sendMessage(
+        messageSenderThread: MessageSenderThread,
+        connection: BluetoothConnectionThread,
+        message: Message,
+        isConversation: Boolean
+    ) {
         val messageBytesArray = objectMapper.writeValueAsBytes(message)
-        connection.write(messageBytesArray, messageBytesArray.size, isConversation)
+        messageSenderThread.putMessage(connection, messageBytesArray, messageBytesArray.size, isConversation)
     }
 }

--- a/app/src/main/java/com/p2p/framework/bluetooth/MessageSenderThread.kt
+++ b/app/src/main/java/com/p2p/framework/bluetooth/MessageSenderThread.kt
@@ -1,0 +1,56 @@
+package com.p2p.framework.bluetooth
+
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.LinkedBlockingDeque
+
+class MessageSenderThread : Thread() {
+
+    private var isClosed = false
+    private var messagesQueue: BlockingQueue<ConnectionMessage> = LinkedBlockingDeque()
+
+    init {
+        start()
+    }
+
+    fun close() {
+        isClosed = true
+    }
+
+    fun putMessage(
+        connection: BluetoothConnectionThread,
+        byteArray: ByteArray,
+        length: Int,
+        isConversation: Boolean
+    ) = messagesQueue.put(ConnectionMessage(connection, byteArray, length, isConversation))
+
+    override fun run() {
+        while (!isClosed) {
+            // Wait until a new message arrived and write it
+            messagesQueue.take().write()
+
+            /**
+             * Wait [DELAY_BETWEEN_MESSAGES] seconds between sending messages.
+             *
+             * We must do this because if the messages are sent very closely, one after the other,
+             * then it can cause the receiver to read both at the same time.
+             * If that happens then the second message won't be read.
+             */
+            sleep(DELAY_BETWEEN_MESSAGES)
+        }
+    }
+
+    private class ConnectionMessage(
+        private val connection: BluetoothConnectionThread,
+        private val bytes: ByteArray,
+        private val length: Int,
+        private val isConversation: Boolean
+    ) {
+
+        fun write() = connection.write(bytes, length, isConversation)
+    }
+
+    companion object {
+
+        private const val DELAY_BETWEEN_MESSAGES: Long = 2_000
+    }
+}

--- a/app/src/main/java/com/p2p/model/LoadingMessageType.kt
+++ b/app/src/main/java/com/p2p/model/LoadingMessageType.kt
@@ -1,0 +1,6 @@
+package com.p2p.model
+
+enum class LoadingMessageType {
+    TF_WAITING_FOR_REVIEW,
+    TF_WAITING_FOR_WORDS
+}

--- a/app/src/main/java/com/p2p/presentation/tuttifrutti/ClientTuttiFruttiViewModel.kt
+++ b/app/src/main/java/com/p2p/presentation/tuttifrutti/ClientTuttiFruttiViewModel.kt
@@ -2,8 +2,8 @@ package com.p2p.presentation.tuttifrutti
 
 import com.p2p.data.bluetooth.BluetoothConnectionCreator
 import com.p2p.data.instructions.InstructionsRepository
-import com.p2p.data.loadingMessages.LoadingSource
 import com.p2p.data.loadingMessages.LoadingTextRepository
+import com.p2p.model.LoadingMessageType
 import com.p2p.data.userInfo.UserSession
 import com.p2p.model.base.message.Conversation
 import com.p2p.model.tuttifrutti.message.FinalScoreMessage
@@ -55,13 +55,13 @@ class ClientTuttiFruttiViewModel(
     }
 
     override fun enoughForMeEnoughForAll() {
-        startLoading(loadingTextRepository.getText(LoadingSource.MessageType.TF_WAITING_FOR_REVIEW))
+        startLoading(loadingTextRepository.getText(LoadingMessageType.TF_WAITING_FOR_REVIEW))
         super.enoughForMeEnoughForAll()
     }
 
     override fun onReceiveEnoughForAll(conversation: Conversation) {
         enoughForAllConversation = conversation
-        startLoading(loadingTextRepository.getText(LoadingSource.MessageType.TF_WAITING_FOR_REVIEW))
+        startLoading(loadingTextRepository.getText(LoadingMessageType.TF_WAITING_FOR_REVIEW))
         super.onReceiveEnoughForAll(conversation)
     }
 

--- a/app/src/main/java/com/p2p/presentation/tuttifrutti/ClientTuttiFruttiViewModel.kt
+++ b/app/src/main/java/com/p2p/presentation/tuttifrutti/ClientTuttiFruttiViewModel.kt
@@ -2,10 +2,15 @@ package com.p2p.presentation.tuttifrutti
 
 import com.p2p.data.bluetooth.BluetoothConnectionCreator
 import com.p2p.data.instructions.InstructionsRepository
+import com.p2p.data.loadingMessages.LoadingSource
 import com.p2p.data.loadingMessages.LoadingTextRepository
 import com.p2p.data.userInfo.UserSession
 import com.p2p.model.base.message.Conversation
-import com.p2p.model.tuttifrutti.message.*
+import com.p2p.model.tuttifrutti.message.FinalScoreMessage
+import com.p2p.model.tuttifrutti.message.TuttiFruttiEnoughForMeEnoughForAllMessage
+import com.p2p.model.tuttifrutti.message.TuttiFruttiSendWordsMessage
+import com.p2p.model.tuttifrutti.message.TuttiFruttiStartGameMessage
+import com.p2p.model.tuttifrutti.message.TuttiFruttiStartRoundMessage
 import com.p2p.presentation.basegame.ConnectionType
 import com.p2p.presentation.tuttifrutti.create.categories.Category
 
@@ -50,13 +55,13 @@ class ClientTuttiFruttiViewModel(
     }
 
     override fun enoughForMeEnoughForAll() {
-        startLoading(loadingTextRepository.getText(TuttiFruttiEnoughForMeEnoughForAllMessage.TYPE))
+        startLoading(loadingTextRepository.getText(LoadingSource.MessageType.TF_WAITING_FOR_REVIEW))
         super.enoughForMeEnoughForAll()
     }
 
     override fun onReceiveEnoughForAll(conversation: Conversation) {
         enoughForAllConversation = conversation
-        startLoading(loadingTextRepository.getText(TuttiFruttiEnoughForMeEnoughForAllMessage.TYPE))
+        startLoading(loadingTextRepository.getText(LoadingSource.MessageType.TF_WAITING_FOR_REVIEW))
         super.onReceiveEnoughForAll(conversation)
     }
 

--- a/app/src/main/java/com/p2p/presentation/tuttifrutti/ServerTuttiFruttiViewModel.kt
+++ b/app/src/main/java/com/p2p/presentation/tuttifrutti/ServerTuttiFruttiViewModel.kt
@@ -3,6 +3,7 @@ package com.p2p.presentation.tuttifrutti
 import androidx.lifecycle.viewModelScope
 import com.p2p.data.bluetooth.BluetoothConnectionCreator
 import com.p2p.data.instructions.InstructionsRepository
+import com.p2p.data.loadingMessages.LoadingSource
 import com.p2p.data.loadingMessages.LoadingTextRepository
 import com.p2p.data.userInfo.UserSession
 import com.p2p.model.base.message.Conversation
@@ -79,14 +80,12 @@ class ServerTuttiFruttiViewModel(
         acceptWords(MYSELF_PEER_ID, categoriesWords)
 
     override fun enoughForMeEnoughForAll() {
-        startLoading(loadingMessage = "")
         saidEnough(MYSELF_PEER_ID)
         super.enoughForMeEnoughForAll()
         stopRound()
     }
 
     override fun onReceiveEnoughForAll(conversation: Conversation) {
-        startLoading(loadingMessage = "")
         saidEnough(conversation.peer)
         super.onReceiveEnoughForAll(conversation)
     }
@@ -97,6 +96,7 @@ class ServerTuttiFruttiViewModel(
     }
 
     private fun saidEnough(peer: Long) {
+        startLoading(loadingTextRepository.getText(LoadingSource.MessageType.TF_WAITING_FOR_WORDS))
         saidEnoughPeer = peer
         _finishedRoundInfos.value = emptyList()
         waitingWordsJob = viewModelScope.launch(Dispatchers.Default) {

--- a/app/src/main/java/com/p2p/presentation/tuttifrutti/ServerTuttiFruttiViewModel.kt
+++ b/app/src/main/java/com/p2p/presentation/tuttifrutti/ServerTuttiFruttiViewModel.kt
@@ -3,8 +3,8 @@ package com.p2p.presentation.tuttifrutti
 import androidx.lifecycle.viewModelScope
 import com.p2p.data.bluetooth.BluetoothConnectionCreator
 import com.p2p.data.instructions.InstructionsRepository
-import com.p2p.data.loadingMessages.LoadingSource
 import com.p2p.data.loadingMessages.LoadingTextRepository
+import com.p2p.model.LoadingMessageType
 import com.p2p.data.userInfo.UserSession
 import com.p2p.model.base.message.Conversation
 import com.p2p.model.tuttifrutti.FinishedRoundInfo
@@ -96,7 +96,7 @@ class ServerTuttiFruttiViewModel(
     }
 
     private fun saidEnough(peer: Long) {
-        startLoading(loadingTextRepository.getText(LoadingSource.MessageType.TF_WAITING_FOR_WORDS))
+        startLoading(loadingTextRepository.getText(LoadingMessageType.TF_WAITING_FOR_WORDS))
         saidEnoughPeer = peer
         _finishedRoundInfos.value = emptyList()
         waitingWordsJob = viewModelScope.launch(Dispatchers.Default) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,8 +43,8 @@
 
     <!-- Tutti Frutti - Rounds -->
     <string name="tutti_frutti_rounds">¿Cuántas rondas van a jugar?</string>
-    <string name="decrease_number">Decrease number</string>
-    <string name="increase_number">Increase number</string>
+    <string name="decrease_number">Disminuir número</string>
+    <string name="increase_number">Incrementar número</string>
 
     <!-- How to connect Bluetooth screen -->
     <string name="how_to_connect_bluetooth_title">¿Cómo conectarse con otro dispositivo Bluetooth?</string>
@@ -53,7 +53,7 @@
     <string name="tf_letter"><![CDATA[Letra: <font color=#FF8550>%s</font>]]></string>
     <string name="tf_round"><![CDATA[Ronda: <font color=#FF8550>%d</font>/%d]]></string>
     <string name="tf_validation_error">¡Falta completar!</string>
-    <string name="tf_finish_round">¡Basta para mi, basta para todos!</string>
+    <string name="tf_finish_round">¡Basta para mi, basta para todes!</string>
 
     <!-- Lobby -->
     <string name="lobby_give_help_players_title">Pedile al resto que se sumen</string>
@@ -64,7 +64,8 @@
 
     <string name="tf_enough_player"><![CDATA[¡<b>%s</b> dijo basta!]]></string>
     <!-- Tutti Frutti - Loading screen -->
-    <string name="tf_wait_for_results">¡Discutan con el creador del juego los puntajes!</string>
+    <string name="tf_wait_for_review">¡Discutan con el creador del juego los puntajes!</string>
+    <string name="tf_wait_for_words">Esperando las palabras del resto de les jugadores</string>
     <!-- Tutti Frutti - Final Score -->
     <string name="tf_winner">Ganó %s</string>
     <string name="tf_points">%d puntos</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,7 +64,7 @@
 
     <string name="tf_enough_player"><![CDATA[¡<b>%s</b> dijo basta!]]></string>
     <!-- Tutti Frutti - Loading screen -->
-    <string name="tf_wait_for_review">¡Discutan con el creador del juego los puntajes!</string>
+    <string name="tf_wait_for_review">¡Discutan con quien creó el juego los puntajes!</string>
     <string name="tf_wait_for_words">Esperando las palabras del resto de les jugadores</string>
     <!-- Tutti Frutti - Final Score -->
     <string name="tf_winner">Ganó %s</string>


### PR DESCRIPTION
## Descripción

Tenemos el bug de que a veces las palabras de los clientes no llegan.

Teoría: encontré un caso en el que llegaron los dos mensajes (el de basta y el con la palabras) en el mismo buffer al hacer read(), por lo que creo que como esos 2 mensajes se mandan uno enseguida después del otro, el server los lee como si fueran el mismo. Por eso, el segundo no llega a leerse.
Solución: se agrega un thread encargado del envío de mensajes que deja pasar sí o sí 2 segundos entre cada uno. 

Nota 1: esto podríiiia llegar a tener problemas con memoria porque más threads => más uso de memoria, y le estamos agregando N threads más al server siendo N la cantidad de clientes. Yo me fije el uso de memoria con un cliente y no es grave, pero habría que verificarlo con varios.
Nota 2: esta solución hace que cuando un cliente dice basta, sí o sí tarda 2 segundos en llegar sus palabras al server y por eso le agregué un mensaje en el loading.