### PR TITLE
Updated jackson version to compile

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
                     recyclerView    : '1.2.0'
             ],
             jackson   : '2.4.1',
-            jacksonKotlin   : '2.9.8',
+            jacksonKotlin   : '2.9.6',
             material  : '1.3.0',
             leakCanary: '2.2',
     ]


### PR DESCRIPTION
Como explicado [aca](https://github.com/FasterXML/jackson-module-kotlin/issues/218) es necesario esa version de jackson para que no rompa con versiones particulares de android