### PR TITLE
Fix dialog messages

### DIFF
--- a/app/src/main/java/com/p2p/presentation/truco/TrucoFragment.kt
+++ b/app/src/main/java/com/p2p/presentation/truco/TrucoFragment.kt
@@ -206,15 +206,27 @@ abstract class TrucoFragment<VB : ViewBinding> :
         actionsByPlayer: Map<TrucoPlayerPosition, TrucoAction>,
         onComplete: () -> Unit
     ) {
-        val actionsList = actionsByPlayer.toList()
-        actionsList.forEachIndexed { index, (position, action) ->
-            showPlayerAction(
-                position,
-                action,
-                canAnswer = false,
-                onComplete = onComplete.takeIf { index == actionsList.lastIndex } ?: {}
-            )
-        }
+        showOneOfManyActions(actionsByPlayer.toList(), onComplete)
+    }
+
+    private fun showOneOfManyActions(
+        actions: List<Pair<TrucoPlayerPosition, TrucoAction>>,
+        finalOnComplete: () -> Unit
+    ) {
+        val action = actions.first()
+        showPlayerAction(
+            action.first,
+            action.second,
+            canAnswer = false,
+            onComplete = {
+                val pendingActions = actions.drop(1)
+                if (pendingActions.isEmpty()) {
+                    finalOnComplete()
+                } else {
+                    showOneOfManyActions(pendingActions, finalOnComplete)
+                }
+            }
+        )
     }
 
     private fun showAction(
@@ -271,6 +283,7 @@ abstract class TrucoFragment<VB : ViewBinding> :
         onComplete: () -> Unit
     ) {
         hideTrucoActionsBottomSheet()
+        hideActions()
         bubbleText.text = action.message(requireContext())
         showBubbleView(bubbleBackground)
         showBubbleView(bubbleText)


### PR DESCRIPTION
- Las burbujas de mensaje ahora antes de mostrarse eliminan a la anterior, para no superponerse.
- Hay un delay en el momento de cantar envido, se muestran los puntajes en ronda.

https://user-images.githubusercontent.com/31253446/139950882-a74cb72c-f139-48fd-b340-5756b1c6554f.mp4



