### PR TITLE
Change order of cards in players hand. Add delay between throwing a c…

### DIFF
--- a/app/src/main/java/com/p2p/presentation/truco/TrucoFragment.kt
+++ b/app/src/main/java/com/p2p/presentation/truco/TrucoFragment.kt
@@ -413,7 +413,12 @@ abstract class TrucoFragment<VB : ViewBinding> :
         title.setText(if (isMyTeam) R.string.truco_our_score_label else R.string.truco_their_score_label)
         @SuppressLint("SetTextI18n")
         subtitle.text = "+$earnedPoints"
-        container.fadeIn()
+        container.postDelayed(
+            {
+                container.fadeIn()
+            },
+            SHOW_EARNED_POINTS_DELAY_MS
+        )
         container.postDelayed(
             {
                 container.fadeOut()
@@ -431,6 +436,7 @@ abstract class TrucoFragment<VB : ViewBinding> :
         const val ACTIONS_BOTTOM_SHEET_TAG = "TRUCO_ACTIONS_BOTTOM_SHEET"
         private const val ACTION_BACKGROUND_FINAL_ALPHA = 0.5f
         private const val HIDE_ACTION_BUBBLES_DELAY = 3_000L
-        private const val EARNED_POINTS_DELAY_MS = 3_000L
+        private const val EARNED_POINTS_DELAY_MS = 3_500L
+        private const val SHOW_EARNED_POINTS_DELAY_MS = 1_000L
     }
 }

--- a/app/src/main/java/com/p2p/presentation/truco/cards/TrucoCardsHand.kt
+++ b/app/src/main/java/com/p2p/presentation/truco/cards/TrucoCardsHand.kt
@@ -124,7 +124,7 @@ abstract class TrucoCardsHand(
         val cardsRotation = getCardsRotation(playingCardsSize)
         dragAndDropCardsInHand.forEachIndexed { index, dragAndDropCard ->
             val cardView = dragAndDropCard.cardView
-            cardView.elevation = if (shouldSetCardInitialElevation()) index.toFloat() else 0f
+            cardView.elevation = if (shouldSetCardInitialElevation()) COMPLETE_HAND - index.toFloat() else 0f
             cardView.pivotX = getPivotX() * cardView.measuredWidth.toFloat()
             cardView.pivotY = getPivotY() * cardView.measuredHeight.toFloat()
             cardView.animate()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Se agrega un timeout antes de mostrar los puntos, permitiendo así que cuando se juega una carta de truco se pueda ver bien antes del layout de puntos.
También se cambió el orden de las cartas para poder ver los palos de las cartas negras.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Cuando se tiraba la última carta, no se veía cual era porque aparecía instantaneamente el layout de puntos

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Se jugó una partida de truco. 

## Screenshots (if appropriate):

https://user-images.githubusercontent.com/16126261/140407122-3901b874-0f04-4b89-a3ac-dfbe45e70f36.mp4


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
