### PR TITLE
Truco - Fix finish round because all team lost

### DIFF
--- a/app/src/main/java/com/p2p/presentation/truco/TrucoViewModel.kt
+++ b/app/src/main/java/com/p2p/presentation/truco/TrucoViewModel.kt
@@ -461,9 +461,7 @@ abstract class TrucoViewModel(
         val roundWinner = getRoundWinnerTeamPlayer(currentRoundPlayedCards)?.team
         val hasLostCurrentRound = roundWinner != null && roundWinner != teamWithRoundFinished
         val hasTieCurrentRound = roundWinner == null
-        val hasLostAnyRound = currentHandWinners.any {
-            it != null && it.team != teamWithRoundFinished
-        }
+        val hasLostAnyRound = currentHandWinners.any { it != null && it.team != teamWithRoundFinished }
         val hasTieAnyRound = currentHandWinners.any { it == null }
         return (hasLostCurrentRound && (hasLostAnyRound || hasTieAnyRound)) ||
                 (hasTieCurrentRound && (hasLostAnyRound || (isLastRound() && handPlayer.team != teamWithRoundFinished)))

--- a/app/src/main/java/com/p2p/presentation/truco/TrucoViewModel.kt
+++ b/app/src/main/java/com/p2p/presentation/truco/TrucoViewModel.kt
@@ -461,9 +461,12 @@ abstract class TrucoViewModel(
         val roundWinner = getRoundWinnerTeamPlayer(currentRoundPlayedCards)?.team
         val hasLostCurrentRound = roundWinner != null && roundWinner != teamWithRoundFinished
         val hasTieCurrentRound = roundWinner == null
-        val hasLostAnyRound =
-            currentHandWinners.any { it != null && it.team != teamWithRoundFinished }
-        return (hasLostCurrentRound && (hasLostAnyRound || isLastRound())) || (hasTieCurrentRound && hasLostAnyRound)
+        val hasLostAnyRound = currentHandWinners.any {
+            it != null && it.team != teamWithRoundFinished
+        }
+        val hasTieAnyRound = currentHandWinners.any { it == null }
+        return (hasLostCurrentRound && (hasLostAnyRound || hasTieAnyRound)) ||
+                (hasTieCurrentRound && (hasLostAnyRound || (isLastRound() && handPlayer.team != teamWithRoundFinished)))
     }
 
     private fun hasCurrentHandFinished(): Boolean {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Se corrige el caso en que un equipo pierde toda la ronda después de haber empatado una anterior ==> se termina la ronda.